### PR TITLE
Don't set explicit CRT options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,6 @@ include_directories(${MLAS_SRC_DIR})
 function(setup_mlas_source_for_windows)
     # The onnxruntime_target_platform variable was added by Windows AI team in onnxruntime_common.cmake
     # Don't use it for other platforms.
-    set_target_properties(mlas PROPERTIES
-        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL"
-    )
     if(onnxruntime_target_platform STREQUAL "x64")
         file(GLOB_RECURSE mlas_platform_srcs_avx CONFIGURE_DEPENDS
             "${MLAS_SRC_DIR}/intrinsics/avx/*.cpp"


### PR DESCRIPTION
Rely on standard CRT option or externally set by OpenVINO